### PR TITLE
Add resources to response

### DIFF
--- a/lib/mio-express.js
+++ b/lib/mio-express.js
@@ -197,6 +197,8 @@ exports.get = function (req, res, next) {
 
     if (resource) {
 
+      res._body = resource;
+
       /**
        * Emitted by route handlers on GET response.
        *
@@ -206,7 +208,7 @@ exports.get = function (req, res, next) {
       this.emit('response', res);
       this.emit('response:get', res);
 
-      res.status(200).send(resource);
+      res.status(200).send(res._body);
     } else {
       next(HttpError(404, 'Not Found'));
     }
@@ -281,6 +283,8 @@ exports.post = function (req, res, next) {
       }));
     }
 
+    res._body = result;
+
     /**
      * Emitted by route handlers on POST response.
      *
@@ -290,7 +294,7 @@ exports.post = function (req, res, next) {
     Resource.emit('response', res);
     Resource.emit('response:post', res);
 
-    res.status(201).send(result);
+    res.status(201).send(res._body);
   }
 };
 
@@ -341,22 +345,32 @@ exports.put = function (req, res, next) {
 
       var prefer = req.get('prefer');
 
-      /**
-       * Emitted by route handlers on PUT response.
-       *
-       * @event response:put
-       * @param {express.Response} response
-       */
-      Resource.emit('response', res);
-      Resource.emit('response:put', res);
-
       if (status === 201) {
-        res.status(201).send(resource);
+        res._body = resource;
+
+        /**
+         * Emitted by route handlers on PUT response.
+         *
+         * @event response:put
+         * @param {express.Response} response
+         */
+        Resource.emit('response', res);
+        Resource.emit('response:put', res);
+
+        res.status(201).send(res._body);
       } else {
         // support RFC 7240 `Prefer` header
         if (prefer && prefer.match(/return=representation/i)) {
-          res.status(200).send(resource);
+          res._body = resource;
+
+          Resource.emit('response', res);
+          Resource.emit('response:put', res);
+
+          res.status(200).send(res._body);
         } else {
+          Resource.emit('response', res);
+          Resource.emit('response:put', res);
+
           res.status(204).end();
         }
       }
@@ -419,19 +433,24 @@ exports.patch = function (req, res, next) {
 
         var prefer = req.get('prefer');
 
-        /**
-         * Emitted by route handlers on PATCH response.
-         *
-         * @event response:patch
-         * @param {express.Response} response
-         */
-        Resource.emit('response', res);
-        Resource.emit('response:patch', res);
-
         // support RFC 7240 `Prefer` header
         if (prefer && prefer.match(/return=representation/i)) {
-          res.status(200).send(resource);
+          res._body = resource;
+
+          /**
+           * Emitted by route handlers on PATCH response.
+           *
+           * @event response:patch
+           * @param {express.Response} response
+           */
+          Resource.emit('response', res);
+          Resource.emit('response:patch', res);
+
+          res.status(200).send(res._body);
         } else {
+          Resource.emit('response', res);
+          Resource.emit('response:patch', res);
+
           res.status(204).end();
         }
       });
@@ -520,10 +539,12 @@ exports.collection.get = function (req, res, next) {
   this.Collection.get(req.query, function(err, collection) {
     if (err) return next(err);
 
+    res._body = collection;
+
     Resource.emit('response', res);
     Resource.emit('response:get', res);
 
-    res.status(200).send(collection);
+    res.status(200).send(res._body);
   });
 };
 
@@ -572,13 +593,18 @@ exports.collection.patch = function (req, res, next) {
 
       var prefer = req.get('prefer');
 
-      this.emit('response', res);
-      this.emit('response:patch', res);
-
       // support RFC 7240 `Prefer` header
       if (prefer && prefer.match(/return=representation/i)) {
-        res.status(200).send(resources);
+        res._body = resources;
+
+        this.emit('response', res);
+        this.emit('response:patch', res);
+
+        res.status(200).send(res._body);
       } else {
+        this.emit('response', res);
+        this.emit('response:patch', res);
+
         res.status(204).end();
       }
     });


### PR DESCRIPTION
After adding response events, you can't modify the body because the response explicitly sends the resource after the events fire. Also the response has no reference to the resource(s). To fix that, I attached a reference to the resource of collection before firing the response events (as needed). Then I send the reference.

Example implementation
```js
res._body = resource;
this.emit('response', res);
res.status(200).send(res._body);
```