### PR TITLE
Retain data that was set on query during a PUT

### DIFF
--- a/lib/mio-express.js
+++ b/lib/mio-express.js
@@ -330,13 +330,17 @@ exports.put = function (req, res, next) {
     if (err) return next(err);
 
     var status = 204;
+    var query = req.query;
 
     if (!resource) {
       status = 201;
       resource = new this();
+      query.where = resource.primaryKeyQuery().query.where;
     }
 
-    resource.set(req.body).put(function(err) {
+    resource.set(req.body);
+
+    this.put(query, resource.toJSON(), function(err, resource) {
       if (err) return next(err);
 
       var prefer = req.get('prefer');


### PR DESCRIPTION
When attaching a `request` event handler that modifies the query data and a `put` hook that reads the query, the data previously modified (or set) is missing. This is because the instance `.put()` overwrites the query with `.primaryKeyQuery()` before the hook is executed.

__Changes:__
* Use static put instead of instance put
* If the resource does not previously exist then overwrite `query.where` with `primaryKeyQuery().query.where`

__Notes__
I'm not sure if this is the correct way to do it. Feel free to comment. I may have noticed that `defaultPageSize` is not obeyed when calling `primaryKeyQuery()`, but I didn't verify. Also, for some reason the PUT tests weren't passing unless I used hooks.