### PR TITLE
Use callback resource in PUT response

### DIFF
--- a/lib/mio-express.js
+++ b/lib/mio-express.js
@@ -336,7 +336,7 @@ exports.put = function (req, res, next) {
       resource = new this();
     }
 
-    resource.set(req.body).put(function(err) {
+    resource.set(req.body).put(function(err, resource) {
       if (err) return next(err);
 
       var prefer = req.get('prefer');

--- a/test/mio-express.js
+++ b/test/mio-express.js
@@ -331,10 +331,11 @@ describe('plugin', function() {
       User.get = function(query, cb) {
         cb.call(this);
       };
-      User.prototype.put = function(cb) {
-        this.reset({ id: 123, name: 'jeff'});
-        cb();
-      };
+      User.hook('put', function (query, data, cb, resource) {
+        data.id = 123;
+        resource.set(data);
+        cb(null, resource);
+      });
       request(app)
         .put('/users/123')
         .send({ name: 'jeff' })


### PR DESCRIPTION
The plugin assumes that any PUT hooks will not modify the resource. This change exposes the resource returned in the callback and uses that instead of the resource prior to that in the response.