### PR TITLE
Expose resource in callback

### DIFF
--- a/lib/mio-express.js
+++ b/lib/mio-express.js
@@ -214,8 +214,12 @@ exports.get = function (req, res, next) {
         this.trigger('response', res, function (err) {
           if (err) return next(err);
 
-          this.trigger('response:get', res, resource, function (err) {
+          this.trigger('response:get', res, resource, function (err, _resource) {
             if (err) return next(err);
+
+            if (_resource !== undefined) {
+              resource = _resource;
+            }
 
             if (resource) {
               res.status(200).send(resource);
@@ -308,8 +312,12 @@ exports.post = function (req, res, next) {
         Resource.trigger('response', res, function (err) {
           if (err) return next(err);
 
-          Resource.trigger('response:post', res, result, function (err) {
+          Resource.trigger('response:post', res, result, function (err, _result) {
             if (err) return next(err);
+
+            if (_result !== undefined) {
+              result = _result;
+            }
 
             res.status(201).send(result);
           });
@@ -380,8 +388,12 @@ exports.put = function (req, res, next) {
           Resource.trigger('response', res, function (err) {
             if (err) return next(err);
 
-            Resource.trigger('response:put', res, resource, function (err) {
+            Resource.trigger('response:put', res, resource, function (err, _resource) {
               if (err) return next(err);
+
+              if (_resource !== undefined) {
+                resource = _resource;
+              }
 
               if (status === 201) {
                 res.status(201).send(resource);
@@ -467,8 +479,12 @@ exports.patch = function (req, res, next) {
         Resource.trigger('response', res, function (err) {
           if (err) return next(err);
 
-          Resource.trigger('response:patch', res, resource, function (err) {
+          Resource.trigger('response:patch', res, resource, function (err, _resource) {
             if (err) return next(err);
+
+            if (_resource !== undefined) {
+              resource = _resource;
+            }
 
             if (resource) {
               resource.patch(function(err) {
@@ -607,8 +623,12 @@ exports.collection.get = function (req, res, next) {
            * @param {mio.Resource.Collection} collection
            * @param {Function} next
            */
-          Resource.trigger('response:collection:get', res, collection, function (err) {
+          Resource.trigger('response:collection:get', res, collection, function (err, _collection) {
             if (err) return next(err);
+
+            if (_collection !== undefined) {
+              collection = _collection;
+            }
 
             res.status(200).send(collection);
           });
@@ -684,8 +704,12 @@ exports.collection.patch = function (req, res, next) {
              * @param {mio.Resource.Collection} collection
              * @param {Function} next
              */
-            this.trigger('response:collection:patch', res, resources, function (err) {
+            this.trigger('response:collection:patch', res, resources, function (err, _resources) {
               if (err) return next(err);
+
+              if (_resources !== undefined) {
+                resources = _resources;
+              }
 
               // support RFC 7240 `Prefer` header
               if (prefer && prefer.match(/return=representation/i)) {


### PR DESCRIPTION
Currently, any modifications to the resource via a response hook will not be reflected in the response body. This change exposes the resource in the callback so that it will be sent with the response. If no resource is passed into the callback (or the resource is not defined) then the original unmodified resource is sent with the response.